### PR TITLE
Fix line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 MVG info is a simple tool to fetch interruption notifications for Munich's public transport system. 
 It currently outputs the data in a [BitBar]-compatible way.
 
-![](https://user-images.githubusercontent.com/12208771/85631491-ebb29680-b675-11ea-9e7d-fe7ac65eeed7.png)
+![](https://user-images.githubusercontent.com/12208771/85635106-67641180-b67d-11ea-82a9-9530a68c1138.png)
 
 ## Installation
 

--- a/internal/bitbar/bitbar.go
+++ b/internal/bitbar/bitbar.go
@@ -50,13 +50,17 @@ func (p *Printer) addInterruption(i interruption.Interruption) {
 }
 
 func (p *Printer) writeln(label, text string) {
+	if !strings.HasSuffix(text, "\n") {
+		text += "\n"
+	}
 	fullText := text
 	if label != "" {
 		fullText = fmt.Sprintf("%s: %s", label, text)
 	}
 	fullText = strings.Replace(fullText, "<br />", "\n", -1)
 
-	p.builder.WriteString(fmt.Sprintf("%s\n", p.trimLineLength(fullText)))
+	trimmedLines := strings.Split(p.trimLineLength(fullText), "\n")
+	p.builder.WriteString(strings.Join(trimmedLines, " | trim=false\n"))
 }
 
 // Print writes the previously added Interruptions out to a writer

--- a/internal/bitbar/bitbar_test.go
+++ b/internal/bitbar/bitbar_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	longMockText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. <br />Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+	longMockText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. <br /><br />Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
 )
 
 var (
@@ -72,30 +72,32 @@ func TestPrinter_Print(t *testing.T) {
 			},
 		},
 		`🚇3️
----
-Updated: Wed Jan 1 10:00:00 UTC
-Affected lines: U1, 42, X999
-Important message
-Simple text
-Duration: Some time
----
-Updated: Wed Jan 1 10:00:00 UTC
-Short message
-Simple text
----
-Updated: Wed Jan 1 10:00:00 UTC
-Affected lines: U1, 42, X999
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-aliqua.
-Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
-irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-aliqua.
-Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
-irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-Duration: Some time
+--- | trim=false
+Updated: Wed Jan 1 10:00:00 UTC | trim=false
+Affected lines: U1, 42, X999 | trim=false
+Important message | trim=false
+Simple text | trim=false
+Duration: Some time | trim=false
+--- | trim=false
+Updated: Wed Jan 1 10:00:00 UTC | trim=false
+Short message | trim=false
+Simple text | trim=false
+--- | trim=false
+Updated: Wed Jan 1 10:00:00 UTC | trim=false
+Affected lines: U1, 42, X999 | trim=false
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna | trim=false
+aliqua. | trim=false
+ | trim=false
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute | trim=false
+irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat | trim=false
+cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. | trim=false
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna | trim=false
+aliqua. | trim=false
+ | trim=false
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute | trim=false
+irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat | trim=false
+cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. | trim=false
+Duration: Some time | trim=false
 `,
 	}
 


### PR DESCRIPTION
Empty lines were previously trimmed out by BitBar unless instructed otherwise, so this instruction is now there.
<img width="866" alt="Screenshot 2020-06-25 at 00 45 06" src="https://user-images.githubusercontent.com/12208771/85635106-67641180-b67d-11ea-82a9-9530a68c1138.png">